### PR TITLE
Use arctan2 for calculating pert_motion_field as opposed to arctan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Switch to using np.arctan2 rather than np.arctan for Probabilistic Advection [#2](https://github.com/dmidk/SolarSTEPS/pull/2), @KristianHMoller
+

--- a/Models/ProbabilisticAdvection.py
+++ b/Models/ProbabilisticAdvection.py
@@ -62,8 +62,9 @@ class ProbabilisticAdvection(object):
         else:
             raise Exception('angle_pert_dist must be either normal or vonmises')
 
-        pert_motion_field[0, :, :] = pert_abs * np.cos(np.arctan(y / x) + beta_noise)
-        pert_motion_field[1, :, :] = pert_abs * np.sin(np.arctan(y / x) + beta_noise)
+        base_angle = np.arctan2(y, x)
+        pert_motion_field[0, :, :] = pert_abs * np.cos(base_angle + beta_noise)
+        pert_motion_field[1, :, :] = pert_abs * np.sin(base_angle + beta_noise)
 
         yhat_maps = self.extrapolate(self.last_map,
                                      pert_motion_field,

--- a/Models/ProbabilisticAdvection.py
+++ b/Models/ProbabilisticAdvection.py
@@ -62,6 +62,7 @@ class ProbabilisticAdvection(object):
         else:
             raise Exception('angle_pert_dist must be either normal or vonmises')
 
+        # Use arctan2 for angle calculation to handle all quadrants correctly
         base_angle = np.arctan2(y, x)
         pert_motion_field[0, :, :] = pert_abs * np.cos(base_angle + beta_noise)
         pert_motion_field[1, :, :] = pert_abs * np.sin(base_angle + beta_noise)


### PR DESCRIPTION
We noted, that even with the `alpha` and `beta` noise parameters both set to zero, running `probabilistic_advection` in ensemble mode yielded results different from those obtained in deterministic mode. The difference was not constant and for some weather scenarios, almost no difference was observed, while for others the difference was large. Specifically, in ensemble mode, "artifacts" would appear in the nowcast.

The source of the discrepancy was tracked to the calculation of `pert_motion_field` in the script `Models/ProbabilisticAdvection.py`. The original code:

```
        pert_motion_field[0, :, :] = pert_abs * np.cos(np.arctan(y / x) + beta_noise)
        pert_motion_field[1, :, :] = pert_abs * np.sin(np.arctan(y / x) + beta_noise)
```
`np.arctan` does not consider the signs of the input values and additionally, for `x=0` this will yield issues with division by zero. https://numpy.org/doc/stable/reference/generated/numpy.arctan.html

By replacing `np.arctan` with `np.arctan2`, these issues seem to be solved. https://numpy.org/doc/stable/reference/generated/numpy.arctan2.html